### PR TITLE
Setting baseContextsToSynchronize in the provisioner was not sufficient

### DIFF
--- a/6.5/default/idm/sync-with-ldap-bidirectional/conf/audit.json
+++ b/6.5/default/idm/sync-with-ldap-bidirectional/conf/audit.json
@@ -87,9 +87,7 @@
                 ]
             },
             "watchedFields" : [ ],
-            "passwordFields" : [
-                "password"
-            ]
+            "passwordFields" : [ ]
         }
     },
     "exceptionFormatter" : {

--- a/6.5/default/idm/sync-with-ldap-bidirectional/conf/sync.json
+++ b/6.5/default/idm/sync-with-ldap-bidirectional/conf/sync.json
@@ -77,7 +77,7 @@
             "onCreate" : {
                 "type" : "text/javascript",
                 "globals" : { },
-                "source" : "target.dn = 'uid=' + source.userName + ',&{userstore.basecontext}';"
+                "source" : "target.dn = 'uid=' + source.userName + ',ou=people,&{userstore.basecontext}';"
             },
             "properties" : [
                 {
@@ -138,7 +138,7 @@
                     "transform" : {
                         "type" : "text/javascript",
                         "globals" : { },
-                        "source" : "\"uid=\" + source + \",&{userstore.basecontext}\""
+                        "source" : "\"uid=\" + source + \",ou=people,&{userstore.basecontext}\""
                     }
                 }
             ],


### PR DESCRIPTION
Setting baseContextsToSynchronize in the provisioner was not sufficient as there is a hard coded mapping in sync.json also.  Hence modified the dn's in onCreate() in sync.json to properly map to the ou=people container.