### PR TITLE
Fix hard wired realm alias for openam

### DIFF
--- a/6.5/smoke-tests/am/global/Realms/root.json
+++ b/6.5/smoke-tests/am/global/Realms/root.json
@@ -11,6 +11,6 @@
     "parentPath" : null,
     "active" : true,
     "name" : "/",
-    "aliases" : [ "userstore", "openam.smoke.forgeops.com", "openam" ]
+    "aliases" : [ "userstore", "&{fqdn}", "openam" ]
   }
 }


### PR DESCRIPTION
The realm alias for root was hard wired. Fix is to parameterise with fqdn. 