### PR TITLE
removed amurl from introspect route

### DIFF
--- a/6.5/cdm/m-cluster/ig/config/routes-service/03-rs-tokenintrospect.json
+++ b/6.5/cdm/m-cluster/ig/config/routes-service/03-rs-tokenintrospect.json
@@ -20,7 +20,7 @@
               "name": "token-resolver-1",
               "type": "TokenIntrospectionAccessTokenResolver",
               "config": {
-                "endpoint": "http://&{AMURL}/oauth2/introspect",
+                "endpoint": "http://openam.&{namespace}.svc.cluster.local/oauth2/introspect",
                 "providerHandler": {
                   "type": "Chain",
                   "config": {


### PR DESCRIPTION
this isn't required for CDM but just tidying up incase we use this route another time.