### PR TITLE
Removed the references to release branches in the README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,6 @@
 # forgeops-init
 
 Holds initial configuration for the ForgeRock platform components. 
- 
-
-NOTE: You must check out the branch of this project that corresponds to the ForgeOps project branch you are using.
-For example, if you are using the release/6.0.0 forgeops project, checkout the release/6.0.0 branch of
-this project. 
-
-The master of this repository tracks the master of the forgeops project.
-
 
 ## About This Repository
 


### PR DESCRIPTION
Removing a couple of paragraphs in the README that no longer apply now that we're using directories in the master branch to associate configurations with FR Identity Platform releases.