### PR TITLE
Adds custom end-user-ui as an oauth2 client

### DIFF
--- a/6.5/oauth2/amster/config/realms/root/OAuth2Clients/endUserUIClient.json
+++ b/6.5/oauth2/amster/config/realms/root/OAuth2Clients/endUserUIClient.json
@@ -1,0 +1,79 @@
+{
+  "metadata" : {
+    "realm" : "/",
+    "amsterVersion" : "6.5.0",
+    "entityType" : "OAuth2Clients",
+    "entityId" : "endUserUIClient",
+    "pathParams" : { }
+  },
+  "data" : {
+    "_id" : "endUserUIClient",
+    "signEncOAuth2ClientConfig" : {
+      "idTokenEncryptionMethod" : "A128CBC-HS256",
+      "jwkSet" : null,
+      "idTokenEncryptionAlgorithm" : "RSA-OAEP-256",
+      "userinfoResponseFormat" : "JSON",
+      "jwksCacheTimeout" : 3600000,
+      "userinfoSignedResponseAlg" : null,
+      "requestParameterEncryptedAlg" : null,
+      "tokenEndpointAuthSigningAlgorithm" : "RS256",
+      "idTokenEncryptionEnabled" : false,
+      "userinfoEncryptedResponseEncryptionAlgorithm" : "A128CBC-HS256",
+      "publicKeyLocation" : "jwks_uri",
+      "requestParameterEncryptedEncryptionAlgorithm" : "A128CBC-HS256",
+      "jwkStoreCacheMissCacheTime" : 60000,
+      "idTokenSignedResponseAlg" : "RS256",
+      "idTokenPublicEncryptionKey" : null,
+      "userinfoEncryptedResponseAlg" : null,
+      "jwksUri" : "http://openam:80/oauth2/connect/jwk_uri",
+      "requestParameterSignedAlg" : null,
+      "clientJwtPublicKey" : null
+    },
+    "advancedOAuth2ClientConfig" : {
+      "grantTypes" : [ "authorization_code", "implicit" ],
+      "updateAccessToken" : null,
+      "requestUris" : [ ],
+      "clientUri" : [ ],
+      "mixUpMitigation" : false,
+      "logoUri" : [ ],
+      "tokenEndpointAuthMethod" : "client_secret_post",
+      "sectorIdentifierUri" : null,
+      "isConsentImplied" : true,
+      "contacts" : [ ],
+      "responseTypes" : [ "code", "token", "id_token", "code token", "token id_token", "code id_token", "code token id_token", "device_code", "device_code id_token" ],
+      "policyUri" : [ ],
+      "descriptions" : [ ],
+      "subjectType" : "Public",
+      "name" : [ ]
+    },
+    "coreOpenIDClientConfig" : {
+      "jwtTokenLifetime" : 0,
+      "clientSessionUri" : null,
+      "postLogoutRedirectUri" : [ ],
+      "defaultMaxAge" : 600,
+      "claims" : [ ],
+      "defaultAcrValues" : [ ],
+      "defaultMaxAgeEnabled" : false
+    },
+    "coreOAuth2ClientConfig" : {
+      "authorizationCodeLifetime" : 0,
+      "accessTokenLifetime" : 0,
+      "defaultScopes" : [ ],
+      "clientName" : [ ],
+      "clientType" : "Public",
+      "scopes" : [ "openid", "profile", "profile_update", "consent_read", "workflow_tasks", "notifications" ],
+      "agentgroup" : null,
+      "refreshTokenLifetime" : 0,
+      "redirectionUris" : [ "https://end-user-ui.sample.forgeops.com/appAuthHelperRedirect.html", "https://end-user-ui.sample.forgeops.com/sessionCheck.html","http://localhost:8081/appAuthHelperRedirect.html", "http://localhost:8081/sessionCheck.html" ],
+      "status" : "Active"
+    },
+    "coreUmaClientConfig" : {
+      "claimsRedirectionUris" : [ ]
+    },
+    "_type" : {
+      "_id" : "OAuth2Client",
+      "name" : "OAuth2 Clients",
+      "collection" : true
+    }
+  }
+}

--- a/6.5/oauth2/development/README.md
+++ b/6.5/oauth2/development/README.md
@@ -72,6 +72,7 @@ Install Minikube: https://kubernetes.io/docs/tasks/tools/install-minikube/
     echo "$(minikube ip) \
         login.sample.forgeops.com \
         rs.sample.forgeops.com" \
+        end-user-ui.sample.forgeops.com \
     | sudo tee -a /etc/hosts
     ```
 
@@ -114,14 +115,20 @@ Install Minikube: https://kubernetes.io/docs/tasks/tools/install-minikube/
 
     You may also find it useful to import this CA certificate into your operating system's trust store. Consult your OS documentation for how to do so.
 
-8. You can access the platform by opening this URL:
+8. You can access the platform by opening this URL (to get the default client):
 
     ```
-    https://login.sample.forgeops.com/console
+    https://end-user-ui.sample.forgeops.com/
     ```
 
     You can use amadmin / password to login as the am admin.
     You can use user.0  / password to login as a basic end-user.
+
+    You can also open this URL to access the AM admin console:
+
+    ```
+    https://login.sample.forgeops.com/console
+    ```
 
     Review the [Access the running platform](../README.md#accessing-the-running-platform) section of the general project README for more details.
 
@@ -151,7 +158,7 @@ Install the Google Cloud SDK: https://cloud.google.com/sdk/install
     gcloud container clusters get-credentials eng-shared --zone us-east1-c --project engineering-devops
     ```
 
-    Run this command in your terminal - this will setup kubectl for your use. Afterward, set your kubectl context to use your own namespace (named from your currently-logged-in name):
+    Run this command in your terminal - this will setup kubectl for your use. Afterwards, set your kubectl context to use your own namespace (named from your currently-logged-in name):
 
     ```
     kubectl config set-context my-context --cluster=`kubectl config current-context` --user=`kubectl config current-context` --namespace=`whoami| sed -e "s/\./_/"`
@@ -217,11 +224,16 @@ Install the Google Cloud SDK: https://cloud.google.com/sdk/install
 
 8. Access the running platform.
 
-    Find the URL to login with using this command:
+    Find the URL for the AM admin console with using this command:
     ```
     echo https://`kubectl get ing -o jsonpath="{.items[0].spec.rules[0].host}" -l chart=openam-6.5.0`/console
     ```
     Open that URL and you will be redirected to the AM login page.
+
+    Find the URL to the default OAuth2 client with this command:
+    ```
+    echo https://`kubectl get ing -o jsonpath="{.items[0].spec.rules[0].host}" -l chart=end-user-ui-0.1.0`/
+    ```
 
     You can use amadmin / password to login as the am admin.
     You can use user.0  / password to login as a basic end-user.

--- a/6.5/oauth2/development/skaffold.yaml
+++ b/6.5/oauth2/development/skaffold.yaml
@@ -8,6 +8,8 @@ build:
     context: ../amster
   - image: gcr.io/engineering-devops/skaffold/oauth2/idm
     context: ../idm
+  - image: gcr.io/engineering-devops/skaffold/oauth2/end-user-ui
+    context: ../end-user-ui
   tagPolicy:
     sha256: {}
   local:
@@ -24,6 +26,14 @@ deploy:
         domain: .forgeops.com
         secret.env.IG_CLIENT_USERNAME: "openig"
         secret.env.IG_CLIENT_PASSWORD: "openig"
+    - name: sk-end-user-ui
+      setValues:
+        domain: .forgeops.com
+      chartPath: helm/end-user-ui
+      values:
+        image: gcr.io/engineering-devops/skaffold/oauth2/end-user-ui
+      imageStrategy:
+        helm: {}
     - name: sk-amster
       chartPath: helm/amster
       valuesFiles:

--- a/6.5/oauth2/end-user-ui/Dockerfile
+++ b/6.5/oauth2/end-user-ui/Dockerfile
@@ -1,0 +1,9 @@
+FROM forgerock-docker-public.bintray.io/forgerock/end-user-ui:6.5.0
+
+WORKDIR /tmp/end-user-ui
+
+RUN git remote add jakefeasel https://github.com/jakefeasel/end-user-ui.git && git fetch jakefeasel && git checkout oauth2
+
+RUN npm install && npm run build
+
+WORKDIR /tmp/end-user-ui/dist


### PR DESCRIPTION
Supplies a built-in client to the oauth2 platform, based on the fork of the end-user-ui currently maintained here: https://github.com/jakefeasel/end-user-ui/tree/oauth2

Uses the new helm chart and docker file introduced to forgeops in this PR: https://github.com/ForgeRock/forgeops/pull/521