### PR TITLE
Removing list of servers from the "LDAP Server" values 

### DIFF
--- a/6.5/cdm/m-cluster/am/realms/root/OpenDJ/OpenDJ.json
+++ b/6.5/cdm/m-cluster/am/realms/root/OpenDJ/OpenDJ.json
@@ -42,7 +42,7 @@
       "sun-idrepo-ldapv3-config-search-scope" : "SCOPE_SUB",
       "sun-idrepo-ldapv3-config-time-limit" : 10,
       "openam-idrepo-ldapv3-heartbeat-interval" : 10,
-      "sun-idrepo-ldapv3-config-ldap-server" : [ "userstore:1389", "userstore-1:userstore:1389", "userstore-0.userstore:1389" ],
+      "sun-idrepo-ldapv3-config-ldap-server" : [ "userstore:1389" ],
       "openam-idrepo-ldapv3-heartbeat-timeunit" : "SECONDS",
       "sun-idrepo-ldapv3-config-organization_name" : "ou=identities",
       "sun-idrepo-ldapv3-config-connection-mode" : "LDAP",


### PR DESCRIPTION
The actual name in the json file is sun-idrepo-ldapv3-config-ldap-server.  Just leaving the round robined userstore value.  This seems to resolve dispropionate load on one of the usersstores although if both AM servers resolve to the same host then again there is a possibility of causing imbalance.