### PR TITLE
Cloud 1118 new ig sim

### DIFF
--- a/6.5/benchmarks/gatling-simulation-files/ig/IGAccessTokensNoCacheSim.scala
+++ b/6.5/benchmarks/gatling-simulation-files/ig/IGAccessTokensNoCacheSim.scala
@@ -1,0 +1,40 @@
+package ig
+
+import io.gatling.core.Predef._
+import io.gatling.core.scenario.Simulation
+import io.gatling.core.structure.ScenarioBuilder
+import io.gatling.http.Predef._
+import io.gatling.http.protocol.HttpProtocolBuilder
+
+class IGAccessTokensSim extends Simulation {
+
+  val concurrency: Integer = Integer.getInteger("concurrency", 10)
+  val duration: Integer = Integer.getInteger("duration", 600)
+  val warmup: Integer = Integer.getInteger("warmup", 1)
+  val igHost: String = System.getProperty("ig_host", "openig.prod.perf.forgerock-qa.com")
+  val igPort: String = System.getProperty("ig_port", "443")
+  val igProtocol: String = System.getProperty("ig_protocol", "https")
+    
+  val igUrl: String = igProtocol + "://" + igHost + ":" + igPort
+  val random = new util.Random
+
+  val csvFile: String = System.getProperty("csv_file_path", "/tmp/tokens.csv")
+  
+  val httpProtocol: HttpProtocolBuilder = http
+    .baseURLs(igUrl)
+    .inferHtmlResources()
+    .header("Accept-API-Version", "resource=2.0, protocol=1.0")
+    
+  val accessTokenScenario: ScenarioBuilder = scenario("IG Token Info flow")
+    .during(duration) {
+      feed(csv(csvFile).random)
+        .exec(
+          http("tokeninfo")
+            .post("/rs-tokeninfo-nocache")
+            .header("Authorization", "Bearer ${tokens}")
+            .check(status.is(200))
+        )
+    }
+    
+  setUp(accessTokenScenario.inject(rampUsers(concurrency) over warmup)).protocols(httpProtocol)
+}

--- a/6.5/benchmarks/gatling-simulation-files/ig/IGAccessTokensNoCacheSim.scala
+++ b/6.5/benchmarks/gatling-simulation-files/ig/IGAccessTokensNoCacheSim.scala
@@ -6,7 +6,7 @@ import io.gatling.core.structure.ScenarioBuilder
 import io.gatling.http.Predef._
 import io.gatling.http.protocol.HttpProtocolBuilder
 
-class IGAccessTokensSim extends Simulation {
+class IGAccessTokensNoCacheSim extends Simulation {
 
   val concurrency: Integer = Integer.getInteger("concurrency", 10)
   val duration: Integer = Integer.getInteger("duration", 600)

--- a/6.5/cdm/m-cluster/ig/config/routes-service/04-rs-tokeninfo-nocache.json
+++ b/6.5/cdm/m-cluster/ig/config/routes-service/04-rs-tokeninfo-nocache.json
@@ -1,6 +1,6 @@
 {
-  "name": "02-rs-tokeninfo",
-  "condition": "${matches(request.uri.path, '^/rs-tokeninfo')}",
+  "name": "02-rs-tokeninfo-nocache",
+  "condition": "${matches(request.uri.path, '^/rs-tokeninfo-nocache')}",
   "monitor": false,
   "heap": [],
   "handler": {
@@ -25,7 +25,7 @@
               }
             },
             "cache": {
-              "enabled": true,
+              "enabled": false,
               "defaultTimeout": "1 hour",
               "maxTimeout": "1 day"
             }


### PR DESCRIPTION
Added separate IG route for CDM config for AccessTokenSim with no cache.
Created separate benchmark simulation to point at new route.

This is to save having to switch the IG config in forgeops-init between benchmarks to disable caching.