### PR TITLE
Overrides IG image pull policy

### DIFF
--- a/7.0/oauth2/development/rs-values.yaml
+++ b/7.0/oauth2/development/rs-values.yaml
@@ -1,3 +1,5 @@
+  image:
+    pullPolicy: IfNotPresent
   domain: forgeops.com
   service:
     name: rs-service


### PR DESCRIPTION
Missed this during my last PR. The current value for pullPolicy in IG breaks skaffold.