### PR TITLE
Update jdbc URL to use database name

### DIFF
--- a/6.5/default/idm/sync-with-ldap-bidirectional/conf/datasource.jdbc-default.json
+++ b/6.5/default/idm/sync-with-ldap-bidirectional/conf/datasource.jdbc-default.json
@@ -1,6 +1,6 @@
 {
     "driverClass" : "org.postgresql.Driver",
-    "jdbcUrl" : "jdbc:postgresql://&{openidm.repo.host}:&{openidm.repo.port}/&{openidm.repo.schema}",
+    "jdbcUrl" : "jdbc:postgresql://&{openidm.repo.host}:&{openidm.repo.port}/&{openidm.repo.databaseName}",
     "databaseName" : "&{openidm.repo.databaseName}",
     "username" : "&{openidm.repo.user}",
     "password" : "&{openidm.repo.password}",


### PR DESCRIPTION
In the JDBC URL after the last slash is supposed to be the database name and not the schema name, see: https://jdbc.postgresql.org/documentation/head/connect.html

Additionally, it looks like IDM internally uses the database name as the schema name, see org.forgerock.openidm.repo.jdbc.impl.JDBCRepoService