### PR TITLE
FRAAS-135 - use ForgeRockIAMDirectoryService rather than OpenDJ for u…

### DIFF
--- a/platform/idm-am-common-user/amster/config/realms/root/ForgeRockIAMDirectoryServer/DS For ForgeRock IAM.json
+++ b/platform/idm-am-common-user/amster/config/realms/root/ForgeRockIAMDirectoryServer/DS For ForgeRock IAM.json
@@ -2,12 +2,12 @@
   "metadata" : {
     "realm" : "/",
     "amsterVersion" : "7.0.0-SNAPSHOT",
-    "entityType" : "OpenDJ",
-    "entityId" : "OpenDJ",
+    "entityType" : "ForgeRockIAMDirectoryServer",
+    "entityId" : "DS For ForgeRock IAM",
     "pathParams" : { }
   },
   "data" : {
-    "_id" : "OpenDJ",
+    "_id" : "DS For ForgeRock IAM",
     "groupconfig" : {
       "sun-idrepo-ldapv3-config-groups-search-attribute" : "cn",
       "sun-idrepo-ldapv3-config-group-container-value" : "groups",
@@ -20,15 +20,16 @@
     },
     "userconfig" : {
       "sun-idrepo-ldapv3-config-auth-kba-attempts-attr" : [ "kbaInfoAttempts" ],
-      "sun-idrepo-ldapv3-config-user-objectclass" : [ "iplanet-am-managed-person", "inetuser", "sunFMSAML2NameIdentifier", "inetorgperson", "devicePrintProfilesContainer", "iplanet-am-user-service", "iPlanetPreferences", "pushDeviceProfilesContainer", "forgerock-am-dashboard-service", "organizationalperson", "top", "kbaInfoContainer", "person", "sunAMAuthAccountLockout", "oathDeviceProfilesContainer", "webauthnDeviceProfilesContainer", "iplanet-am-auth-configuration-service", "fr-idm-managed-user-explicit" ],
+      "sun-idrepo-ldapv3-config-user-objectclass" : [ "iplanet-am-managed-person", "inetuser", "sunFMSAML2NameIdentifier", "inetorgperson", "devicePrintProfilesContainer", "iplanet-am-user-service", "iPlanetPreferences", "pushDeviceProfilesContainer", "forgerock-am-dashboard-service", "organizationalperson", "top", "kbaInfoContainer", "person", "sunAMAuthAccountLockout", "oathDeviceProfilesContainer", "webauthnDeviceProfilesContainer", "iplanet-am-auth-configuration-service",
+        "fr-idm-managed-user-explicit" ],
       "sun-idrepo-ldapv3-config-people-container-name" : "ou",
       "sun-idrepo-ldapv3-config-auth-kba-attr" : [ "kbaInfo" ],
       "sun-idrepo-ldapv3-config-isactive" : "inetuserstatus",
-      "sun-idrepo-ldapv3-config-users-search-attribute" : "uid",
+      "sun-idrepo-ldapv3-config-users-search-attribute" : "fr-idm-uuid",
       "sun-idrepo-ldapv3-config-users-search-filter" : "(objectclass=inetorgperson)",
       "sun-idrepo-ldapv3-config-people-container-value" : "people",
       "sun-idrepo-ldapv3-config-active" : "Active",
-      "sun-idrepo-ldapv3-config-user-attributes" : [ "fr-idm-effectiveRole", "iplanet-am-auth-configuration", "iplanet-am-user-alias-list", "iplanet-am-user-password-reset-question-answer", "mail", "pwdExpireWarning", "assignedDashboard", "authorityRevocationList", "dn", "fr-idm-kbaInfo", "iplanet-am-user-password-reset-options", "employeeNumber", "createTimestamp", "kbaActiveIndex", "pwdMinLength", "caCertificate", "iplanet-am-session-quota-limit", "iplanet-am-user-auth-config", "sun-fm-saml2-nameid-infokey", "sunIdentityMSISDNNumber", "iplanet-am-user-password-reset-force-reset", "sunAMAuthInvalidAttemptsData", "devicePrintProfiles", "givenName", "iplanet-am-session-get-valid-sessions", "objectClass", "adminRole", "inetUserHttpURL", "iplanet-am-user-account-life", "postalAddress", "userCertificate", "preferredtimezone", "iplanet-am-user-admin-start-dn", "oath2faEnabled", "preferredlanguage", "sun-fm-saml2-nameid-info", "userPassword", "iplanet-am-session-service-status", "telephoneNumber", "iplanet-am-session-max-idle-time", "fr-idm-role", "distinguishedName", "iplanet-am-session-destroy-sessions", "kbaInfoAttempts", "modifyTimestamp", "uid", "iplanet-am-user-success-url", "iplanet-am-user-auth-modules", "kbaInfo", "fr-idm-lastSync", "memberOf", "sn", "fr-idm-accountStatus", "preferredLocale", "manager", "iplanet-am-session-max-session-time", "cn", "oathDeviceProfiles", "webauthnDeviceProfiles", "pwdCheckQuality", "iplanet-am-user-login-status", "fr-idm-effectiveAssignment", "fr-idm-preferences", "fr-idm-password", "pushDeviceProfiles", "push2faEnabled", "inetUserStatus", "fr-idm-consentedMapping", "iplanet-am-user-failure-url", "iplanet-am-session-max-caching-time" ],
+      "sun-idrepo-ldapv3-config-user-attributes" : [ "fr-idm-uuid", "etag", "fr-idm-effectiveRole", "iplanet-am-auth-configuration", "iplanet-am-user-alias-list", "iplanet-am-user-password-reset-question-answer", "mail", "pwdExpireWarning", "assignedDashboard", "authorityRevocationList", "dn", "fr-idm-kbaInfo", "iplanet-am-user-password-reset-options", "employeeNumber", "createTimestamp", "kbaActiveIndex", "pwdMinLength", "caCertificate", "iplanet-am-session-quota-limit", "iplanet-am-user-auth-config", "sun-fm-saml2-nameid-infokey", "sunIdentityMSISDNNumber", "iplanet-am-user-password-reset-force-reset", "sunAMAuthInvalidAttemptsData", "devicePrintProfiles", "givenName", "iplanet-am-session-get-valid-sessions", "objectClass", "adminRole", "inetUserHttpURL", "iplanet-am-user-account-life", "postalAddress", "userCertificate", "preferredtimezone", "iplanet-am-user-admin-start-dn", "oath2faEnabled", "preferredlanguage", "sun-fm-saml2-nameid-info", "userPassword", "iplanet-am-session-service-status", "telephoneNumber", "iplanet-am-session-max-idle-time", "fr-idm-role", "distinguishedName", "iplanet-am-session-destroy-sessions", "kbaInfoAttempts", "modifyTimestamp", "uid", "iplanet-am-user-success-url", "iplanet-am-user-auth-modules", "kbaInfo", "fr-idm-lastSync", "memberOf", "sn", "fr-idm-accountStatus", "preferredLocale", "manager", "iplanet-am-session-max-session-time", "cn", "oathDeviceProfiles", "webauthnDeviceProfiles", "pwdCheckQuality", "iplanet-am-user-login-status", "fr-idm-effectiveAssignment", "fr-idm-preferences", "fr-idm-password", "pushDeviceProfiles", "push2faEnabled", "inetUserStatus", "fr-idm-consentedMapping", "iplanet-am-user-failure-url", "iplanet-am-session-max-caching-time" ],
       "sun-idrepo-ldapv3-config-createuser-attr-mapping" : [ "cn", "sn" ],
       "sun-idrepo-ldapv3-config-auth-kba-index-attr" : "kbaActiveIndex",
       "sun-idrepo-ldapv3-config-inactive" : "Inactive"
@@ -70,8 +71,8 @@
       "sun-idrepo-ldapv3-config-auth-naming-attr" : "uid"
     },
     "_type" : {
-      "_id" : "LDAPv3ForOpenDS",
-      "name" : "OpenDJ",
+      "_id" : "LDAPv3ForForgeRockIAM",
+      "name" : "ForgeRock IAM Directory Server",
       "collection" : true
     }
   }

--- a/platform/idm-am-common-user/development/amster-values.yaml
+++ b/platform/idm-am-common-user/development/amster-values.yaml
@@ -1,10 +1,13 @@
-  domain: forgeops.com
-  amadminPassword: password
-  userStore:
-    host: userstore-0.userstore
-  resources:
-    requests:
-      memory: "64Mi"
-  config:
-    strategy: files
-    importPath: /opt/amster/config/
+domain: forgeops.com
+amadminPassword: password
+resources:
+  requests:
+    memory: "64Mi"
+config:
+  strategy: files
+  importPath: /opt/amster/config/
+configStore:
+  host: userstore-0.userstore
+userStore:
+  storeType: "LDAPv3ForForgeRockIAM"
+  host: userstore-0.userstore

--- a/platform/idm-am-common-user/development/openam-values.yaml
+++ b/platform/idm-am-common-user/development/openam-values.yaml
@@ -1,4 +1,8 @@
   domain: forgeops.com
+  image:
+    repository: gcr.io/forgerock-io/am/docker-build
+    tag: latest
+    pullPolicy: IfNotPresent
   service:
     name: openam
     type: NodePort
@@ -6,3 +10,4 @@
     internalPort: 8080
   configSecret: userstore
   configLdapHost: userstore-0.userstore
+  configSecretName: userstore

--- a/platform/idm-am-common-user/idm/conf/repo.ds.json
+++ b/platform/idm-am-common-user/idm/conf/repo.ds.json
@@ -300,11 +300,10 @@
             "managed/user": {
                 "dnTemplate": "ou=people,ou=identities",
                 "namingStrategy": {
-                    "type": "serverNaming",
-                    "dnAttribute": "uid",
-                    "idAttribute": "entryUUID"
+                    "type": "clientDnNaming",
+                    "dnAttribute": "fr-idm-uuid"
                 },
-                "nativeId" : true,
+                "nativeId" : false,
                 "objectClasses": [
                     "person",
                     "organizationalPerson",
@@ -326,12 +325,15 @@
                 ],
                 "properties": {
                     "_id": {
+                        "primaryKey": true,
                         "type": "simple",
-                        "ldapAttribute": "entryUUID",
-                        "writability": "createOnly"
+                        "ldapAttribute": "fr-idm-uuid"
+                    },
+                    "_rev": {
+                        "type": "simple",
+                        "ldapAttribute": "etag"
                     },
                     "userName": {
-                        "primaryKey": true,
                         "type": "simple",
                         "ldapAttribute": "uid"
                     },


### PR DESCRIPTION
Updates forgeops-init for DS as a shared repo (idm-am-common-user) to utilise the latest AM's datastore representation, aligns _id (to the new fr-id-uuid) and _rev and ensures directory communication via uid=admin